### PR TITLE
Fix #1 (Converting circular structure to JSON error)

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = ({ db, table, object, key, updateIgnore = [] }) => {
   keys.forEach(field =>
     assert(
       _.has(object, field),
-      `Key "${field}" is missing in ${JSON.stringify(object)}`
+      `Key "${field}" is missing.`
     )
   )
 


### PR DESCRIPTION
Fixes #1.

I opted in for removing `JSON.stringify` completely, because `util.inspect(object)` was too verbose and messy (example below).

But if you feel like we should do something else, please let me know and I'll amend this PR.

Thanks!

--------------

## util.inspect(object) example

```
Key "id" is missing in { updated_at:␊
       Raw {␊
         client:␊
          Client_SQLite3 {␊
            config: [Object],␊
            connectionSettings: {},␊
            valueForUndefined: null,␊
            _events: [Object],␊
            _eventsCount: 4,␊
            makeKnex: [Function: makeKnex],␊
            acquireConnection: [Function: acquireConnection],␊
            acquireRawConnection: [Function],␊
            releaseConnection: [Function],␊
            driverName: 'mocked',␊
            destroyRawConnection: [Function: destroyRawConnection],␊
            processResponse: [Function: processResponse] },␊
         sql: 'CURRENT_TIMESTAMP',␊
         bindings: undefined,␊
         _wrappedBefore: undefined,␊
         _wrappedAfter: undefined,␊
         _debug: undefined,␊
         circular: [Circular] } }`,
```